### PR TITLE
Add frontend development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Este es el codex de Buda.com. Acá encontrarás set de guías para Devs de [Buda
 
 Grande Buda.com <3
 
+Esta documentación está hecha con [docsify](https://docsify.js.org/#/)
+
 ## Únete a la nave espacial
 
 Estamos contratando, revisa los puestos [aquí](https://www.buda.com/trabaja-en-buda)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Este es el codex de Buda.com. Acá encontrarás set de guías para Devs de [Buda.com](https://www.buda.com/chile) (y el mundo), acuerdos que tomamos para que nos comuniquemos mejor y mantengamos una misma cultura en el código y más allá.
 
-## Creditos
+## Créditos
 
 Grande Buda.com <3
 

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,4 @@
+- [Home](/#introducción)
+- Guías
+  - [Frontend](/guias/frontend)
+    - [Convenciones sobre queries](/guias/queries.md)

--- a/guias/frontend.md
+++ b/guias/frontend.md
@@ -1,0 +1,4 @@
+# Guía de desarrollo frontend
+
+### [Convenciones sobre queries y funciones de fetch](/guias/queries.md)
+En nuestro frontend web, hacemos nuestras llamadas a la API desde el frontend usando Axios y React Query. [Acá](/guias/queries.md) puedes leer más sobre cómo ordenar los correspondientes archivos.

--- a/guias/queries.md
+++ b/guias/queries.md
@@ -1,0 +1,38 @@
+# Convenciones sobre queries y funciones de fetch
+
+Esta convención indica cómo se deben llamar y ordenar los archivos que contienen los queries de [React Query](https://tanstack.com/query/v4/) y las funciones que hacen las llamadas a la API.
+
+### TL;DR:
+> Queries y calls se agregan en una carpeta `/api` dentro de cada carpeta de feature. Ejemplo de nombre de query: `useFetchTransactions`. Ejemplo de nombre de call: `fetchTransactions`.
+
+
+### Contexto
+
+Para interactuar con la API desde el frontend, usamos la librería [React Query](https://tanstack.com/query/v4/), que ofrece hooks como `useQuery` y `useMutation` con funcionalidades como manejo de estado, manejo de errores, estrategias de refetching, caching, etc. Sobre estos hooks tenemos wrappers para agregar configuración. A estos wrappers les llamaremos **queries** y puedes ver un ejemplo [acá](https://github.com/budacom/surbtc/blob/master/app/react/features/investments/api/useFetchTransactions.ts).
+
+Pero React Query no hace la llamada misma a la API. A los queries hay que entregarles una función que hace la llamada. A estas funciones les llamaremos **calls** (por detrás usan Axios) y puedes ver un ejemplo [acá](https://github.com/budacom/surbtc/blob/master/app/react/features/investments/api/fetchTransactions.ts).
+
+### Detalle de decisiones
+
+¿Cómo ordenamos las queries y calls?
+
+En cada carpeta de feature (por ejemplo `/investments`) o en la carpeta `/shared`, debe existir una carpeta `/api` que contiene las queries y calls. Si crece mucho la carpeta (en número de archivos), se puede separar en dos, una para queries y otra para calls.
+
+Cada query tiene su propio archivo, y cada call tiene su propio archivo.
+
+
+Las **queries** y sus correspondientes archivos tienen que llamarse de la forma `use<Action><Resource>`. Por ejemplo `useFetchTransactions`. Con Action nos referimos a un nombre descriptivo de lo que hace la llamada a la API (fetch, create, delete, update, cancel, etc.), no al verbo HTTP. 
+
+Las **calls** y sus correspondientes archivos tienen que llamarse de la forma `<action><Resource>`. 
+Por ejemplo: `fetchTransactions`.
+
+### Ejemplo
+
+Puedes ver un ejemplo en el [directorio de la feature de inversiones](https://github.com/budacom/surbtc/tree/master/app/react/features/investments) en SurBTC, que tiene un archivo [api/fetchTransactions.ts](https://github.com/budacom/surbtc/blob/master/app/react/features/investments/api/fetchTransactions.ts) y un archivo [api/useFetchTransaction.ts](https://github.com/budacom/surbtc/blob/master/app/react/features/investments/api/useFetchTransactions.ts)
+
+```
+investments/
+  api/
+    fetchTransactions.ts
+    useFetchTransactions.ts
+```

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       repo: 'https://github.com/budacom/the-codex',
       coverpage: true,
       themeColor: '#12D3C6',
+      loadSidebar: true,
     }
   </script>
   <!-- Docsify v4 -->


### PR DESCRIPTION
Se agrega la guía de desarrollo frontend, como una manera de compartir los estándares que define el chapter de frontend.

Se agrega la primera parte de la guía: Convenciones sobre queries y funciones de fetch. El documento original está en notion [acá](https://www.notion.so/budapuntocom/Convenciones-sobre-queries-y-funciones-de-fetch-da91cc48ed0c484db5b35549751f5c54).

<img width="2287" alt="image" src="https://user-images.githubusercontent.com/20808297/193650039-c568af66-6c11-4ba8-8e87-be78be3d5809.png">
