### PR TITLE
fix: cambio del baseUrl en docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,8 +8,8 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
 const config = {
   title: "Buda.com Codex",
   tagline: "Guías, estándares y otros de Buda.com",
-  url: "https://budacom.github.io/the-codex",
-  baseUrl: "/",
+  url: "https://budacom.github.io/",
+  baseUrl: "/the-codex/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",


### PR DESCRIPTION
### Contexto

Hay un warning de la configuración de docusaurus que avisa que no se pueden usar slug dentro de a url.

### Cambios realizados

Se mueve el slug `the-codex` a `baseUrl` para cumplir con la recomendación.