### PR TITLE
fix: redireccionar desde el home usando baseUrl

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,5 +2,5 @@ import React from "react";
 import { Redirect } from "@docusaurus/router";
 
 export default function Home() {
-  return <Redirect to="/intro" />;
+  return <Redirect to="/the-codex/intro" />;
 }


### PR DESCRIPTION
### Contexto

El home no está redireccionando correctamente a intro porque no está considerando la `baseUrl`.

### Cambios realizados

Se actualiza el redirect del home para considerar la `baseUrl`: `the-codex/intro`.