### PR TITLE
fix: agregar permisos para pages en el deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### Contexto

Se agregan permisos de escritura en páginas en el archivo de deploy.