### PR TITLE
feat: sección api mock en testing frontend

### DIFF
--- a/docs/guia-frontend/testing/_category_.json
+++ b/docs/guia-frontend/testing/_category_.json
@@ -1,0 +1,9 @@
+{
+  "label": "Testing",
+  "position": 2,
+  "link": {
+    "type": "generated-index",
+    "slug": "testing",
+    "description": "Convenciones y buenas prácticas que utilizamos para testing."
+  }
+}

--- a/docs/guia-frontend/testing/api-mocks.md
+++ b/docs/guia-frontend/testing/api-mocks.md
@@ -1,0 +1,185 @@
+---
+sidebar_position: 2
+---
+
+# Mocks de API calls
+
+Para los mocks de API calls utilizamos la librería [Mock Service Worker](https://mswjs.io/) que nos permite hacer
+mocks de manera universal, que por una parte elimina la necesidad de tener que utilizar un mock para cada librería
+de request que tengamos y también simplifica la configuración.
+
+## Ejemplo de uso 🔍
+
+En nuestro ejemplo tenemos un componente `<NewsBanner />` que representa un banner que ve el usuario al ingresar
+al sitio web y tiene un botón para cerrarlo o para dirigirnos a otra vista. Este componente debe ser presentado
+hasta un máximo de 3 veces al usuario:
+
+```tsx title="src/features/news-banner/index.tsx"
+const NewsBanner = () => {
+  // ...
+  return (
+    <div>
+      // ...
+      <Button
+        // ...
+        onPress={...}
+        testID="news-banner-close"
+      />
+      <Button
+        // ...
+        onPress={...}
+        testID="news-banner-yes"
+      />
+    </div>
+  );
+};
+```
+
+### Definición de un mock 🎯
+
+Se recomienda dejar los mocks de requests en el mismo directorio, en nuestro caso `src/mocks`. Y asimismo, contar con un
+archivo donde tener todos nuestros request handlers, en nuestro caso `src/mocks/handlers.js`.
+
+► **Request handlers**
+
+Para el caso de api REST podemos simular cualquier tipo de request `rest`: `get`, `post`, `put`, `patch` o `delete`.
+Al mockear estas requests podremos capturar cualquier solicitud y especificar qué respuesta devolver.
+
+```js title="src/mocks/handlers.js"
+// highlight-start
+import { rest } from "msw";
+// highlight-end
+
+export const handlers = [
+  // Handles a POST /login request
+  // highlight-start
+  rest.post("/login", null),
+  // highlight-end
+];
+```
+
+► **Response resolver**
+
+Para manejar una request capturada, especificamos una response simulada mediante una función. La función que resuelve
+la response puede recibir los siguientes argumentos:
+
+- `req`, información del request: `get`, `post`, etc.,
+- `res`, para crear el mock de la response,
+- `ctx`, un conjunto de funciones para setear: `status`, `headers`, `body`, etc. del mock de la respuesta.
+
+```js title="src/mocks/handlers.js"
+import { apiBaseUrl } from "@/values/api";
+// highlight-start
+import { rest } from "msw";
+// highlight-end
+
+export const handlers = [
+  // Handles a GET /user_metadata request
+  // highlight-start
+  rest.get(`${apiBaseUrl}/user_metadata`, (req, res, ctx) =>
+    res(
+      ctx.json({
+        user_metadata: {
+          value: '{"count":2}',
+        },
+      })
+    )
+  ),
+  // highlight-end
+];
+```
+
+### Uso del mock 📝
+
+Si queremos utilizar la respuesta del request previamente definido en `src/mocks/handlers.js`
+y así validar algún cambio en el DOM, sólo es necesario esperar que se renderize el componente
+con `waitFor`:
+
+```js title="src/features/news-banner/__tests__/index.spec.js"
+// ...
+
+const renderComponent = () =>
+  render(
+    <MockRest>
+      <NewsBanner />
+    </MockRest>
+  );
+
+describe("NewsBanner", () => {
+  it("displays when flag is active and user has seen the banner less than 3 times", async () => {
+    const { getByTestId } = renderComponent();
+
+    // highlight-start
+    await waitFor(() => getByTestId("news-banner"));
+
+    expect(getByTestId("news-banner")).toBeTruthy();
+    // highlight-end
+  });
+});
+```
+
+Por otra parte, si queremos sobrescribir la respuesta del request lo podemos hacer utilizando
+`server.use`. En este caso, para hacer uso del mock utilizamos la función `waitForRequest` para
+esperar la respuesta del request y así validar algún cambio en el DOM:
+
+```js title="src/features/news-banner/__tests__/index.spec.js"
+// ...
+
+const renderComponent = () =>
+  render(
+    <MockRest>
+      <NewsBanner />
+    </MockRest>
+  );
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("NewsBanner", () => {
+  it("does not shows when the user has seen the banner more than 3 times", async () => {
+    // highlight-start
+    server.use(
+      rest.get(`${apiBaseUrl}/user_metadata`, (req, res, ctx) =>
+        res(
+          ctx.json({
+            user_metadata: {
+              value: '{"count":3}',
+            },
+          })
+        )
+      )
+    );
+    // highlight-end
+
+    const { queryByTestId } = renderComponent();
+
+    // highlight-start
+    await act(async () => {
+      await waitForRequest("GET", "/user_metadata");
+      await sleep(100);
+    });
+
+    expect(queryByTestId("news-banner")).toBeNull();
+    // highlight-end
+  });
+});
+```
+
+:::info
+Al sobreescribir `rest.get` utilizando `server.use`, lo que hacemos es sobreescribir la respuesta por
+defecto que se encuentra definida en `src/mocks/handlers.js`:
+
+```js
+user_metadata: {
+  value: '{"count":2}',
+}
+```
+
+Y la cambiamos por:
+
+```js
+user_metadata: {
+  value: '{"count":3}',
+}
+```
+
+:::

--- a/docs/guia-frontend/testing/file-location.md
+++ b/docs/guia-frontend/testing/file-location.md
@@ -1,12 +1,8 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 ---
 
-# Testing
-
-Convenciones y buenas prácticas que utilizamos para testing.
-
-## Ubicación de los archivos
+# Ubicación de los archivos
 
 Para el caso de los test unitarios utilizamos una forma con más acoplamiento, es decir, que los archivos de test
 se encuentren cercanos al código que queremos testear.
@@ -16,7 +12,7 @@ Utilizamos las carpetas `/__tests__` y `/__snapshots__` dentro de cada carpeta d
 de ruta: `/src/components/ComponentX/__tests__`.
 :::
 
-### Contexto
+## Contexto
 
 Si bien no existe un estándar único, hay un relativo consenso de que es mejor tener más acoplamiento, que menos.
 
@@ -41,7 +37,7 @@ Si bien no existe un estándar único, hay un relativo consenso de que es mejor 
   - ❌ Dificultad para encontrar tests específicos.
   - ❌ Poca visibilidad respecto a tests pendientes. Se está menos consciente de los tests.
 
-### ¿Cómo ordenamos los tests de los componentes? 🎯
+## ¿Cómo ordenamos los tests de los componentes? 🎯
 
 En cada carpeta de un componente (por ejemplo `/components/ComponentX`), tendremos una
 carpeta `/__tests__` que contiene los tests del componente, y de considerarse necesario,


### PR DESCRIPTION
### Contexto

Se agrega el ítem _Mocks de API calls_ en la sección Testing de la guía frontend, donde se incluye un ejemplo de uso de la librería [Mock Service Worker](https://mswjs.io/) agregada en https://github.com/budacom/buda-expo/pull/637.

### Cambios realizados

Se agrega la sección `api-mocks` dentro de `testing`, con un ejemplo de uso en los tests.

### Vistas



https://user-images.githubusercontent.com/3976806/205371799-a8461fc9-2e33-4795-9649-7a92db05fbc9.mov








