### PR TITLE
fix(docs/guia-backend/_category_.json): set position to 2

### DIFF
--- a/docs/guia-backend/_category_.json
+++ b/docs/guia-backend/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Guía Backend",
-  "position": 1,
+  "position": 2,
   "link": {
     "type": "generated-index",
     "slug": "guia-backend",


### PR DESCRIPTION
Esto creo que debería arreglar que la sección de backend se vea después que la introducción