### PR TITLE
Actualizar guía de MSW

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --port 3021",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
Se actualiza la guía que explica cómo usar MSW

- Cambié la estructura, ahora está dividido en guía rápida y ejemplo en detalle, cada uno con subsecciones.
- Agregué guía para usar MSW en el navegador
- Agregué mención a los archivos de surbtc además de los de buda-expo
- Simplifiqué un poco el código mostrado en los ejemplos para que tenga solo lo necesario y quité algunas cosas que solo se usan en la app
- Agregué links a la documentación y al código

Mi idea es que la guía sirva de referencia para saber que esto existe, pero que no busque reemplazar ni la documentación oficial ni el código mismo, ambos de los cuales probablemente van a estar más completos y actualizados.

Todo esto es *mi* apreciación de cómo puede mejorar, estoy totalmente abierto a comentarios.

Además aproveché de cambiar el puerto del comando `yarn start` porque antes topaba con el de surbtc.